### PR TITLE
automatically sort posts into upcoming and previous

### DIFF
--- a/previous.md
+++ b/previous.md
@@ -8,14 +8,18 @@ title: Previous Topics
 Previous Topics
 ===============
 
+
 <ul class="listing">
-{% assign past_posts = (site.posts | where: "category" , "posts") %}
-{% for post in past_posts %}
-<li>
-<span>{{ post.date | date: "%B %e, %Y" }}</span>
-<a href="{{ site.url }}{{ post.url }}">
-{{ post.title }} {% if post.author %} &ndash; {{ post.author }} {% endif %}
-</a></li>
+{% assign curDate = site.time | date: '%s' %}
+{% for post in site.posts %}
+    {% assign postStartDate = post.date | date: '%s' %}
+	{% if postStartDate < curDate %}
+	<li>
+	<span>{{ post.date | date: "%B %e, %Y" }}</span>
+	<a href="{{ base }}{{ post.url }}">
+	{{ post.title }} {% if post.author %} &ndash; {{ post.author }} {% endif %}
+	</a></li>
+    {% endif %}
 {% endfor %}
 </ul>
 

--- a/upcoming.md
+++ b/upcoming.md
@@ -18,13 +18,16 @@ charge of that topic to see if they would like to collaborate.
 
 
 <ul class="listing">
-{% assign upcoming = (site.posts | where: "category", "upcoming") %}
-{% for post in upcoming reversed %}
-<li>
-<span>{{ post.date | date: "%B %e, %Y" }}</span>
-<a href="{{ site.url }}{{ post.url }}">
-{{ post.title }} {% if post.author %} &ndash; {{ post.author }} {% endif %}
-</a></li>
+{% assign curDate = site.time | date: '%s' %}
+{% for post in site.posts reversed %}
+    {% assign postStartDate = post.date | date: '%s' %}
+	{% if postStartDate >= curDate %}
+	<li>
+	<span>{{ post.date | date: "%B %e, %Y" }}</span>
+	<a href="{{ base }}{{ post.url }}">
+	{{ post.title }} {% if post.author %} &ndash; {{ post.author }} {% endif %}
+	</a></li>
+    {% endif %}
 {% endfor %}
 </ul>
 


### PR DESCRIPTION
I found this super useful -- no more posts/upcoming categories. Now posts in the future get put in the upcoming page, posts in past go to previous.
